### PR TITLE
Fix the spamming warning about the 'continue' usage within the switch statement

### DIFF
--- a/init.php
+++ b/init.php
@@ -80,7 +80,7 @@ class ff_FeedCleaner extends Plugin
 						$feed_data = self::enc_utf8($feed_data, $config, $debug);
 						break;
 					default:
-						continue;
+						continue 2;
 				}
 			}
 		}


### PR DESCRIPTION
PHP 7.3 warns about the usage of continue within a switch statement without a number. I added a 2 to cleanly escape the outer loop and omit the warning.